### PR TITLE
fix: correct variable reference for file paths

### DIFF
--- a/.github/scripts/update_readme.php
+++ b/.github/scripts/update_readme.php
@@ -2,8 +2,8 @@
 // Пути к файлам
 $ROOT = dirname(__FILE__, 3);
 
-$manifestPath = ROOT . '/manifest.json';
-$readmePath = ROOT . '/README.md';
+$manifestPath = $ROOT . '/manifest.json';
+$readmePath = $ROOT . '/README.md';
 
 // Проверяем наличие manifest.json
 if (!file_exists($manifestPath)) {


### PR DESCRIPTION
Update the file path variable from ROOT to $ROOT in the 
update_readme.php script. This change ensures that the 
correct variable is used to reference the root directory, 
preventing potential errors when accessing the manifest 
and README files.